### PR TITLE
Adding Scalar Root finding algorithm: bisect, regula falsi and ridder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,4 @@
 //!
 pub mod signal;
 pub mod special;
+pub mod optimize;

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -1,0 +1,1 @@
+pub mod root_scalar;

--- a/src/optimize/root_scalar/bisect.rs
+++ b/src/optimize/root_scalar/bisect.rs
@@ -1,0 +1,29 @@
+use std::fmt::{Display, Debug};
+use num::Float;
+
+use crate::optimize::root_scalar::BracketSolver;
+
+/// ## Bisect Algorithm
+pub struct BisectSolver<T>{
+    pos:T,neg:T
+}
+
+impl<T> BracketSolver<T> for BisectSolver<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    fn init(fun:&mut dyn FnMut(T)->T, bracket:(T,T))->Box<Self> {
+        let (pos, neg) = {
+            if fun(bracket.0).is_sign_positive() {bracket}
+            else{ (bracket.1,bracket.0) }
+        };
+        Box::new(Self { pos, neg })
+    }
+    fn new_guess(&mut self,fun:&mut dyn FnMut(T)->T)->(T,T){
+        let mid = (self.pos+self.neg)/T::from(2.0).unwrap();
+        let y = fun(mid);
+        if y.is_sign_positive(){ self.pos = mid; }
+        else{ self.neg = mid; }
+        (mid,y)
+    }
+}

--- a/src/optimize/root_scalar/bracket.rs
+++ b/src/optimize/root_scalar/bracket.rs
@@ -1,0 +1,50 @@
+use num::Float;
+
+
+use crate::optimize::root_scalar::*;
+use crate::optimize::root_scalar::bisect::*;
+use crate::optimize::root_scalar::regula_falsi::*;
+
+/// Specify different type of root finding algorithms
+#[derive(Debug,Clone, Copy)]
+pub enum BracketMethod{
+    /// ## Bisect Algorithm
+    /// repeatly find the mid point between bracket,
+    /// and progressively narrow the bracket to find root by checking the sign
+    Bisect,
+    /// ## Regula Falsi Algorithm/ False Position Algorithm
+    /// Repeatly find the x-intercept `c` of the line that pass througth`(a,f(a))` and `(b,f(b))`
+    /// and narrow the bracket by checking the sign of `f(c)`
+    RegulaFalsi,
+    /// ## Ridder Algorithm
+    /// Base on Regula Falsi.
+    /// 
+    /// Ridders, C. (1979). 
+    /// "A new algorithm for computing a single root of a real continuous function". 
+    /// IEEE Transactions on Circuits and Systems. 26: 979–980. doi:10.1109/TCS.1979.1084580
+    Ridder,
+    Brent,
+}
+
+impl BracketMethod{
+    pub fn get_solver<T>(&self,fun:&mut dyn FnMut(T)->T, bracket:(T,T))-> Box<dyn BracketSolver<T>>
+    where
+        T: PartialEq + PartialOrd + Display + Debug + Float + 'static,
+    {
+        match self {
+            BracketMethod::Bisect=>BisectSolver::init(fun,bracket),
+            BracketMethod::RegulaFalsi=>RegulaFalsiSolver::init(fun, bracket),
+            BracketMethod::Ridder=>RidderSolver::init(fun, bracket),
+            _=>unreachable!(),
+        }
+    }
+}
+
+pub trait BracketSolver<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    fn init(fun:&mut dyn FnMut(T)->T, bracket:(T,T))->Box<Self> where Self:Sized;
+    fn new_guess(&mut self,fun:&mut dyn FnMut(T)->T)->(T,T);
+}
+

--- a/src/optimize/root_scalar/mod.rs
+++ b/src/optimize/root_scalar/mod.rs
@@ -1,0 +1,389 @@
+use std::fmt::{Debug, Display};
+
+use num::{Float, complex::ComplexFloat};
+
+pub mod bracket;
+pub mod bisect;
+pub mod regula_falsi;
+
+pub use bracket::*;
+
+/// The rtol for default solver
+const DFAULT_RTOL    : f64 = 1e-100;
+
+/// The ftol for default solver
+const DFAULT_FTOL    : f64 = 1e-12;
+
+/// The xtol for default solver
+const DFAULT_XTOL    : f64 = 1e-12;
+
+/// The maxiter for default solver
+const DFAULT_MAXITER : u64 = 1000_u64;
+
+
+/// # `RootScalarSolver<T>`
+/// 
+/// ## `where T: PartialEq + PartialOrder + Display + Debug`
+/// The struct that hold all the terminate condition for root finding
+/// 
+/// 
+/// ## field
+/// ### `rtol: Option<T>`
+/// the relative tolorence, if is `Some(_)`, the root finding algorithm will terminate if
+/// `|x - x'| < x' * rtol`
+/// 
+/// ### `ftol: Option<T>`
+/// the evaluated tolorence, if is `Some(_)`, the root finding algorithm will terminate if
+/// `|f(x)| < ftol`
+/// 
+/// ### `xtol: Option<T>`
+/// the absolute tolorence, if is `Some(_)`, the root finding algorithm will terminate if
+/// `|x - x'| < xtol`
+/// 
+/// ### `iter: Option<u64>`
+/// the maximum iteration allowed, if is `Some(_)`, the root finding algorithm will terminate if
+/// `no_of_iter > maxiter`
+/// 
+/// 
+/// ## Example
+/// ### Creation
+/// `RootScalarSolver<T>` implement `Default`,
+/// ```
+/// let solver = RootScalarSolver<f64>::default();
+/// ```
+/// It also utilize builder pattern which allow you to customize with ease
+/// ```
+/// let solver = RootScalarSolver<f64>::default()
+///     .set_rtol(None)
+///     .set_ftol(Some(1e-12))
+///     .set_xtol(None)
+///     .set_maxiter(1e10);
+/// ```
+/// ### Root Finding with Bracket
+/// To find root for a function with bracket, you need to provide:
+/// 1. A function `fun: Fn(T)->T` to find root
+/// 2. the bracket `(a:T,b:T)` that the root might exist in, given that:
+///     - `a` and `b` itself must be finite
+///     - the function `fun` must evaluated to finite at `a` and `b`
+///     - the function `fun` must evaluated to different sign at `a` and `b`
+/// 3. the solving algorithm, which is an enum `BracketMethod` e.g.:
+/// ```
+///     BracketMethod::Bisect
+///     BracketMethod::RegulaFalsi
+///     BracketMethod::Ridder
+///     ...
+/// ````
+/// #### example
+/// ```
+/// let solver = RootScalarSolver::<f64>::default()
+///     .set_rtol(None)
+///     .set_ftol(Some(1e-12));
+/// 
+/// fn fun(x:f64)->f64{ (x.powi(2) + 1.0_f64) * (x - 0.5_f64) }
+/// let bracket = (-10_f64,10_f64);
+/// let method = BracketMethod::Ridder;
+/// 
+/// let res: RootScalarResult<f64> = solver.solve_with_bracket(
+///     &fun, bracket, method
+/// );
+/// 
+/// let res = solver.bisect(&fun,bracket);
+/// ```
+pub struct RootScalarSolver<T>
+where 
+    T: PartialEq + PartialOrd + Display + Debug,
+{
+    rtol: Option<T>,
+    ftol: Option<T>,
+    xtol: Option<T>,
+    maxiter: Option<u64>,
+}
+
+impl<T> RootScalarSolver<T>
+where 
+    T: PartialEq + PartialOrd + Display + Debug + Clone,
+{
+    pub fn set_rtol(mut self, rtol:Option<T>)->Self { self.rtol = rtol; self}
+    pub fn set_ftol(mut self, ftol:Option<T>)->Self { self.ftol = ftol; self}
+    pub fn set_xtol(mut self, xtol:Option<T>)->Self { self.xtol = xtol; self} 
+    pub fn set_maxiter(mut self, maxiter:Option<u64>)->Self { self.maxiter = maxiter; self}
+    pub fn get_rtol(&self)->Option<T> { self.rtol.clone() }
+    pub fn get_ftol(&self)->Option<T> { self.ftol.clone() }
+    pub fn get_xtol(&self)->Option<T> { self.xtol.clone() } 
+    pub fn get_maxiter(&self)->Option<u64> { self.maxiter }
+}
+
+impl<T> Default for RootScalarSolver<T>
+where 
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    fn default() -> Self{
+        Self { 
+            rtol: Some(T::from(DFAULT_RTOL).unwrap()), 
+            ftol: Some(T::from(DFAULT_FTOL).unwrap()), 
+            xtol: Some(T::from(DFAULT_XTOL).unwrap()), 
+            maxiter: Some(DFAULT_MAXITER) 
+        }
+    }
+}
+
+impl<T> RootScalarSolver<T>
+where 
+    T: PartialEq + PartialOrd + Display + Debug + Float + 'static,
+{
+
+    fn validate_bracket(fun:&dyn Fn(T)->T, bracket:(T,T), res: &mut RootScalarResult<T>){        
+        let (a,b) = bracket;
+        if a.is_infinite() || b.is_infinite(){
+            res.flag = RootScalarResultFlag::Fail("Bracket must be finite.".to_string());
+            return;
+        }
+        let (u,v)=(fun(a),fun(b));
+        if u.is_infinite() || v.is_infinite(){
+            res.flag = RootScalarResultFlag::Fail("Bracket must evaluated to be finite.".to_string());
+            return;
+        }
+        if u * v > T::zero(){
+            res.flag = RootScalarResultFlag::Fail("Bracket must evaluate to different sign.".to_string());
+        }
+    }
+    /// ### Root Finding with Bracket
+    /// To find root for a function with bracket, you need to provide:
+    /// 1. A function `fun: Fn(T)->T` to find root
+    /// 2. the bracket `(a:T,b:T)` that the root might exist in, given that:
+    ///     - `a` and `b` itself must be finite
+    ///     - the function `fun` must evaluated to finite at `a` and `b`
+    ///     - the function `fun` must evaluated to different sign at `a` and `b`
+    ///        
+    /// if any of above condition is not met, it will return result with a fail flag
+    /// 
+    /// 3. the solving algorithm, which is an enum `BracketMethod` e.g.:
+    /// ```
+    ///     BracketMethod::Bisect
+    ///     BracketMethod::RegulaFalsi
+    ///     BracketMethod::Ridder
+    ///     ...
+    /// ````
+    pub fn solve_with_bracket(&self, fun:&dyn Fn(T)->T, bracket:(T,T), method: BracketMethod)->RootScalarResult<T> {
+        let mut res = RootScalarResult::<T>::new();
+
+        Self::validate_bracket(&fun, bracket.clone(), &mut res);
+
+        let mut fun = |x|{
+            res.function_called += 1;
+            fun(x)
+        };
+        
+        if res.flag.fail(){
+            return res;
+        }
+
+        let mut solver = method.get_solver(&mut fun,bracket);
+        let mut last_guess = None;
+        
+        loop{
+            let (new_guess,new_y) = solver.new_guess(&mut fun);
+            
+            res.root = new_guess;
+            res.error = new_y;
+
+            if let Some(ftol) = self.ftol{
+                if new_y.abs() < ftol {
+                    res.flag.ftol_reach();
+                    break;
+                }
+            }
+            if let Some(last_guess) = last_guess{
+                if let Some(rtol) = self.rtol{
+                    if (new_guess-last_guess).abs() < new_guess * rtol{
+                        res.flag.rtol_reach();
+                        break;
+                    }
+                }
+    
+                if let Some(xtol) = self.xtol{
+                    if (last_guess-new_guess).abs() < xtol{
+                        res.flag.xtol_reach();
+                        break;
+                    }
+                }
+            }
+            if let Some(maxiter) = self.maxiter{
+                if res.iterations >= maxiter{
+                    res.flag = RootScalarResultFlag::Fail("Fail, max iterations reached".to_string());
+                    break;
+                }
+            }
+            res.iterations += 1;
+            last_guess = Some(new_guess)
+        }
+        res
+    }
+
+    pub fn bisect(&self,fun:&dyn Fn(T)->T,bracket:(T,T))->RootScalarResult<T>{
+        self.solve_with_bracket(fun, bracket, BracketMethod::Bisect)
+    }
+    pub fn regula_falsi(&self,fun:&dyn Fn(T)->T,bracket:(T,T))->RootScalarResult<T>{
+        self.solve_with_bracket(fun, bracket, BracketMethod::RegulaFalsi)
+    }
+    pub fn ridder(&self,fun:&dyn Fn(T)->T,bracket:(T,T))->RootScalarResult<T>{
+        self.solve_with_bracket(fun, bracket, BracketMethod::Ridder)
+    }
+
+}
+
+
+impl<T> RootScalarSolver<T>
+where 
+    T: PartialEq + PartialOrd + Display + Debug + ComplexFloat,
+{}
+
+
+/// ## `RootScalarResult` flag
+/// ```
+/// Running
+/// ```
+/// running, should not be seen, just for internal logic
+/// 
+/// ```
+/// Fail(String)
+/// ```
+/// root finding fail, and reason is stated in the `String`
+/// 
+/// ```
+/// Success{rot:bool,ftol:bool,xtol:bool}
+/// ```
+/// root finding sucess, struct body specify which condition is reached
+#[derive(Debug,Clone)]
+pub enum RootScalarResultFlag{
+    Running,
+    Success{
+        rtol: bool,
+        ftol: bool,
+        xtol: bool,
+    },
+    Fail(String),
+}
+
+impl RootScalarResultFlag{
+    /// return `true` if the flag is `Sucess{_}`
+    pub fn sucess(&self)->bool{
+        match self{
+            Self::Success{rtol:_,ftol:_,xtol:_}=>true,
+            _=>false
+        }
+    }
+    /// return `true` if the flag is `Fail(String)`
+    pub fn fail(&self)->bool{
+        match self{
+            Self::Fail(_)=>true,
+            _=>false
+        }
+    }
+    /// Set `rtol` in `Success` flag to be true,
+    /// if the flag is no `Success` it change it to `Success`
+    pub fn rtol_reach(&mut self){
+        match self {
+            Self::Success { rtol:_, ftol, xtol }=>{
+                *self=Self::Success { rtol: true, ftol:*ftol, xtol:*xtol};
+            }
+            _=>{
+                *self=Self::Success { rtol: true, ftol: false, xtol: false };
+            }
+        }
+    }
+    /// Set `ftol` in `Success` flag to be true,
+    /// if the flag is no `Success` it change it to `Success`
+    pub fn ftol_reach(&mut self){
+        match self {
+            Self::Success { rtol, ftol:_, xtol }=>{
+                *self=Self::Success { rtol: *rtol, ftol:true, xtol:*xtol};
+            }
+            _=>{
+                *self=Self::Success { rtol: false, ftol: true, xtol: false };
+            }
+        }
+    }
+    /// Set `xtol` in `Success` flag to be true,
+    /// if the flag is no `Success` it change it to `Success`
+    pub fn xtol_reach(&mut self){
+        match self {
+            Self::Success { rtol, ftol, xtol:_ }=>{
+                *self=Self::Success { rtol: *rtol, ftol:*ftol, xtol:true};
+            }
+            _=>{
+                *self=Self::Success { rtol: false, ftol: false, xtol: true };
+            }
+        }
+    }
+}
+
+/// # `RootScalarResult<T>`
+/// ## where T: PartialEq + PartialOrd + Display + Debug
+/// Store the result of root finding
+/// ## field
+/// ### `root: T`
+/// the result, the last guess of the algorithm, 
+/// check the flag to see if the algorithm success
+/// 
+/// ### `error: T`
+/// the evaluated error of the guess.
+/// 
+/// ### `iterations: u64`
+/// number of iterations executed.
+/// 
+/// ### `function_called: u64`
+/// number of function called.
+/// 
+/// ### `flag: RootScalarResultFlag`
+/// the flag for of the result, 
+/// indicate the success and fail condition
+pub struct RootScalarResult<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug,
+{
+    pub root: T,
+    pub error: T,
+    pub iterations: u64,
+    pub function_called: u64,
+    pub flag: RootScalarResultFlag,
+}
+
+impl<T>  RootScalarResult<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    fn new() -> Self {
+        Self { 
+            root: T::zero(), 
+            error: T::zero(),
+            iterations: 0, 
+            function_called: 0, 
+            flag: RootScalarResultFlag::Running 
+        }
+    }
+}
+
+impl<T> ToString for RootScalarResult<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug,
+{
+    fn to_string(&self) -> String {
+        vec![
+            format!("root : {:>+10.4}", self.root),
+            format!("error : {:>+10.4}", self.error),
+            format!("iteration : {:>6}", self.iterations),
+            format!("no. of function called : {:>6}", self.function_called),
+            format!("flag : {:?}", self.flag),
+        ].join(", ")
+    }
+}
+
+impl<T> Debug for RootScalarResult<T> 
+where
+    T: PartialEq + PartialOrd + Display + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f,"{}", self.to_string())
+    }    
+}

--- a/src/optimize/root_scalar/mod.rs
+++ b/src/optimize/root_scalar/mod.rs
@@ -187,27 +187,32 @@ where
             res.root = new_guess;
             res.error = new_y;
 
+            if new_y.is_infinite(){
+                res.flag = RootScalarResultFlag::Fail("Function evaluated to be infinite".to_string());
+                break
+            }
+
             if let Some(ftol) = self.ftol{
                 if new_y.abs() < ftol {
                     res.flag.ftol_reach();
-                    break;
                 }
             }
             if let Some(last_guess) = last_guess{
                 if let Some(rtol) = self.rtol{
                     if (new_guess-last_guess).abs() < new_guess * rtol{
                         res.flag.rtol_reach();
-                        break;
                     }
                 }
     
                 if let Some(xtol) = self.xtol{
                     if (last_guess-new_guess).abs() < xtol{
                         res.flag.xtol_reach();
-                        break;
                     }
                 }
             }
+            
+            if res.flag.sucess(){break;}
+
             if let Some(maxiter) = self.maxiter{
                 if res.iterations >= maxiter{
                     res.flag = RootScalarResultFlag::Fail("Fail, max iterations reached".to_string());

--- a/src/optimize/root_scalar/regula_falsi.rs
+++ b/src/optimize/root_scalar/regula_falsi.rs
@@ -1,0 +1,87 @@
+use std::fmt::{Display, Debug};
+use num::Float;
+
+use crate::optimize::root_scalar::BracketSolver;
+
+pub struct RegulaFalsiSolver<T>{
+    pos:T,
+    neg:T,
+    pos_y:T,
+    neg_y:T,
+}
+
+impl<T> BracketSolver<T> for RegulaFalsiSolver<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    fn init(fun:&mut dyn FnMut(T)->T, bracket:(T,T))->Box<Self> {
+        let (pos, neg,pos_y,neg_y) = {
+            let (x1,x2) = bracket;
+            let (y1,y2) = (fun(x1),fun(x2));
+            if y1.is_sign_positive() {(x1,x2,y1,y2)}
+            else{ (x2,x1,y2,y1) }
+        };
+        Box::new(Self { pos, neg, pos_y, neg_y})
+    }
+    fn new_guess(&mut self,fun:&mut dyn FnMut(T)->T)->(T,T){
+        let mid = (self.pos_y*self.neg-self.neg_y*self.pos)/(self.pos_y-self.neg_y+T::epsilon());
+        
+        let y = fun(mid);
+        
+        if y.is_sign_positive(){ self.pos = mid;self.pos_y = y; }
+        else{ self.neg = mid; self.neg_y = y; }
+        
+        (mid,y)
+    }
+}
+
+pub struct RidderSolver<T>{
+    x0:T,
+    x2:T,
+    y0:T,
+    y2:T,
+}
+
+impl<T> BracketSolver<T> for RidderSolver<T>
+where
+    T: PartialEq + PartialOrd + Display + Debug + Float,
+{
+    /*
+    Ridders, C. (1979). 
+    "A new algorithm for computing a single root of a real continuous function". 
+    IEEE Transactions on Circuits and Systems. 26: 979–980. doi:10.1109/TCS.1979.1084580
+    */
+    fn init(fun:&mut dyn FnMut(T)->T, bracket:(T,T))->Box<Self> {
+    let (x0,x2) = bracket;
+        let (y0,y2) = (fun(x0),fun(x2));
+        Box::new(Self { x0,x2,y0,y2})
+    }
+
+    fn new_guess(&mut self,fun:&mut dyn FnMut(T)->T)->(T,T){
+        let x1 = (self.x0 + self.x2)/ T::from(2.0).unwrap();
+        let d = self.x0 - x1;
+
+        let y1 = fun(x1);
+
+        let x3 = x1 + d * (y1/self.y2) / (((y1/self.y0).powi(2)-self.y2/self.y0).sqrt()+T::epsilon());
+        let y3 = fun(x3);
+
+        if (y1/y3).is_sign_negative(){
+            self.x0 = x1;
+            self.y0 = y1;
+            self.x2 = x3;
+            self.y2 = y3;
+        }
+        else if (self.y2/y3).is_sign_negative(){
+            self.x0 = x3;
+            self.y0 = y3;
+        }
+        else{
+            self.x2 = x3;
+            self.y2 = y3;
+        }
+
+        (x3,y3)
+    }
+
+}

--- a/tests/root_scalar.rs
+++ b/tests/root_scalar.rs
@@ -1,0 +1,78 @@
+/*
+    test for sciport-rs::optimize::root_scalar::*
+
+    to run this test, run: cargo test root_scalar -- --nocapture
+*/
+
+use sciport_rs::optimize::root_scalar::*;
+
+const BRACKET: (f64,f64) = (-15.0,12.0);
+const ROOT: f64 = 4_f64;
+
+fn have_root(x:f64)->f64{
+    /* 
+        f(x) = (x^2 + 1) * (x - 4) 
+    */
+    (x.powi(2) + 1_f64) * (x - ROOT)
+}
+fn have_root_2(x:f64)->f64{
+    /* 
+        f(x) = (x^2 + x + 1) * (x - 4) 
+    */
+    (x.powi(2) + x + 1_f64) * (x - ROOT)
+}
+
+fn touching_root(x:f64)->f64{
+    /*
+        f(x) = (x-3)^2
+    */
+    (x-3_f64).powi(2)
+}
+
+fn no_root(x:f64)->f64{
+    /* 
+        f(x) = x^2 + 1 
+    */
+    x.powi(2) + 1_f64
+}
+
+fn inf(_:f64)->f64{
+    /*
+        f(x) = infinity 
+    */
+    f64::INFINITY
+}
+
+#[test]
+fn test_root_scalar() {
+    let rootscalersolver = RootScalarSolver::default();
+
+    let methods = vec![
+        (BracketMethod::Bisect, "Bisect"),
+        (BracketMethod::RegulaFalsi,"Regula Falsi"),
+        (BracketMethod::Ridder,"Ridder")
+    ];
+
+    let funs:Vec<(Box<fn(f64) -> f64>, bool)> = vec![
+        (Box::new(have_root),true),
+        (Box::new(have_root_2),true),
+        (Box::new(touching_root),false),
+        (Box::new(no_root),false),
+        (Box::new(inf),false),
+    ];
+
+    for (method, name) in methods{
+        println!("[{}]",name);
+
+        for (fun,sucess) in funs.iter(){
+            let res = rootscalersolver.solve_with_bracket(&fun, BRACKET, method);
+            
+            println!("  {:?}",res);
+            
+            assert_eq!(res.flag.sucess(),*sucess);
+            if res.flag.sucess(){
+                assert!((res.root - ROOT).abs() < 1e-9);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Preface
I want to help adding some more module, and root finding seems a good place to start.

I am not expert at rust or scientific computing.

It's a long commit, take you time.

thank you very much.

# Meta
I can `cargo build` the project, but I can't link `amo.lib`, there are a `linker error 1181`, I went online to find that that might be issue with Visual Studio build tool, and I fixed that, but the linker error presist, I run my test my deleting all part that required the `amo.lib`/`complex-bessel-rs`, do you know if it is a windows specific problem? Like, is it because some setting in `complex-bessel-rs/build.rs` that compile code only for linux system?

I will try to find some solution, and if it still does work, I will open an issue.


# File 
```
/optimize    <------------------ the optimize root folder, following scipy
    L mod.rs
    L root_scalar/    <--------- the module for scalar root finding
        L mod.rs    <----------- Base iterative root finding logic
        L bracket.rs    <------- the interface for scalar root finding with bracket
        L bisect.rs    <--------    bracket root finding algorithm: Bisect
        L regula_falsi.rs    <--    bracket root finding algorithm: regula_falsi
/test/root_scalar.rs
```
# API
see `test/root_scalar.rs` to see more example of `root_scalar` api.

## Simple example
$f(x)=(x^2+1)(x-0.5)$
```rust
// to make the solver
let solver = RootScalarSolver::<f64>::default()
    .set_rtol(None)
    .set_ftol(Some(1e-12));

// define the function to solve
fn fun(x:f64)->f64{ (x.powi(2) + 1.0_f64) * (x - 0.5_f64) }
// specify the bracket to find root
let bracket = (-10_f64,10_f64);
// specify the bracket-based root finding method
let method = BracketMethod::Ridder;

// get the result
let res: RootScalarResult<f64> = solver.solve_with_bracket(
    &fun, bracket, method
);

// short-hand method
let res = solver.bisect(&fun,bracket);
```

## `RootScalarSolver<T>`
```rust
pub struct RootScalarSolver<T>
where 
    T: PartialEq + PartialOrd + Display + Debug,
{
    rtol: Option<T>,
    ftol: Option<T>,
    xtol: Option<T>,
    maxiter: Option<u64>,
}
```

It has generic for different type of float type: `f64`, `f32`, `f128`..., and also might be complex number, in the future, if I could figure it out.

This is a struct that hold all the iterative root finding algorithm's termination condition, namely `rtol`, `ftol`, `xtol`, `maxiter`.
To see the detail explaination, see `/optimize/root_scalar/mod.rs` to find doc comment of `RootScalarSolver<T>`.

### Implement for Float (real-domain)
```rust
impl<T> RootScalarSolver<T>
where 
    T: PartialEq + PartialOrd + Display + Debug + Float + 'static,
{...
```
This is where the bracket-based root finding algorithm defined, since bracket-based root finding algorithm cannot be use to find complex root.

## `BracketMethod`
```rust
#[derive(Debug,Clone, Copy)]
pub enum BracketMethod{
    Bisect,
    RegulaFalsi,
    Ridder,
    Brent, //<-- not implemented
}
```
The bracket-based root finding algorithms. Only applicable for real value.

## `RootScalarResult<T>`
```rust
pub struct RootScalarResult<T>
where
    T: PartialEq + PartialOrd + Display + Debug,
{
    pub root: T,
    pub error: T,
    pub iterations: u64,
    pub function_called: u64,
    pub flag: RootScalarResultFlag,
}
```
Store the result of the root finding algorithm.

## `RootScalarResultFlag`
```rust
#[derive(Debug,Clone)]
pub enum RootScalarResultFlag{
    Running,
    Success{
        rtol: bool,
        ftol: bool,
        xtol: bool,
    },
    Fail(String),
}
```
Store the terminate condition of the root finding algorithm


# Testing Runing Result
to run only the `root_scalar.rs`'s test.
```bash
cargo test root_scalar -- --nocapture
```
```rust
Running tests\root_scalar.rs (~\target\debug\deps\root_scalar-fe9a190e7d848b97.exe)

running 1 test
[Bisect]
  root :    +4.0000, error :    +0.0000, iteration :     44, no. of function called :     46, flag : Success { rtol: false, ftol: false, xtol: true }
  root :    +4.0000, error :    +0.0000, iteration :     44, no. of function called :     46, flag : Success { rtol: false, ftol: false, xtol: true }
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluated to be finite.")
[Regula Falsi]
  root :    +4.0000, error :    +0.0000, iteration :    320, no. of function called :    323, flag : Success { rtol: false, ftol: false, xtol: true }
  root :    +4.0000, error :    +0.0000, iteration :    241, no. of function called :    244, flag : Success { rtol: false, ftol: false, xtol: true }
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluated to be finite.")
[Ridder]
  root :    +4.0000, error :    +0.0000, iteration :     80, no. of function called :    164, flag : Success { rtol: false, ftol: true, xtol: false }
  root :    +4.0000, error :    +0.0000, iteration :     86, no. of function called :    176, flag : Success { rtol: false, ftol: false, xtol: true }
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluate to different sign.")
  root :    +0.0000, error :    +0.0000, iteration :      0, no. of function called :      0, flag : Fail("Bracket must evaluated to be finite.")
test test_root_scalar ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```